### PR TITLE
fix: Fixed emoji URL

### DIFF
--- a/_includes/steps.html
+++ b/_includes/steps.html
@@ -24,7 +24,7 @@
       <div class="col-md-4 text-center">
         <div class="service-box">
           <p class="emoji">
-            <img alt="Vision" src="https://www.flaticon.com/svg/static/icons/svg/653/653469.svg" height="60">
+            <span alt="Vision">🤖</span>
           </p class="emoji">
           <h3>{{ site.t.fr.steps.step2.title }}</h3>
           <p class="text-muted">


### PR DESCRIPTION
This PR simply fixes the broken URL of the "Vision" icon. To avoid the issue from coming back, I switched from the URL to a unicode emoji!

Here is how it renders now:
![image](https://user-images.githubusercontent.com/26927750/152518342-a340d41c-9170-4a2d-b1a8-1c38abec6e0a.png)


Any feedback is welcome!