### PR TITLE
remove  google analytics - CNIL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,6 @@ locale: fr_FR
 
 # SEO
 google_site_verification: NRZ27lDopfjKH3Lx1eWvh6WczAGh0hgqVg0AtB-ZK6c
-google_analytics: UA-179976746-1
 
 
 # Build settings


### PR DESCRIPTION
## Motivation
Considering [CNIL updates](https://www.cnil.fr/fr/utilisation-de-google-analytics-et-transferts-de-donnees-vers-les-etats-unis-la-cnil-met-en-demeure), could be relevant to not use google analytics

- This PR removes the google analytics tracking ID. 

Hope its relevant as long I am not knowledgeable with SEO and google analytics :)
