### PR TITLE
fix: Fixed D4G logo URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,8 +74,8 @@ t:
       sponsor1:
         title: "Data for Good"
         url: "https://dataforgood.fr/"
-        logo: "https://dataforgood.fr/img/logo-white.png"
-        content: "Membre de la saison 6 et 8 de Data for Good, c'est là que Pyronear a vu le jour parmi de nombreux projets d'intérêt général."
+        logo: "https://dataforgood.fr/img/logo-dfg-new2.png"
+        content: "Membre de la saison 6, 8 et 10 de Data for Good, c'est là que Pyronear a vu le jour parmi de nombreux projets d'intérêt général."
       sponsor2:
         title: "Atraksis"
         url: "https://atraksis.fr/"


### PR DESCRIPTION
This PR fixes the broken URL to D4G logo, and updates the partnership description (added attendance to Season 10).


Before :
![website_issue](https://user-images.githubusercontent.com/26927750/170267101-5c7ecacd-c2d8-4515-999d-833a5a980aca.PNG)

After, replacing D4G logo by:
![D4G logo](https://dataforgood.fr/img/logo-dfg-new2.png)


Any feedback is welcome!
