### PR TITLE
Add Open Data card to manifesto

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,7 +178,7 @@ t:
       card8:
         icon_src: "/img/cards_icons/share.svg"
         title: "Open data" 
-        content: "Nous construisons à l’aide de nos partenaires et bénévoles, un dataset que nous partageons en open data, afin que les images collectées et annotées puissent servir au plus grande nombre."
+        content: "Nous construisons à l’aide de nos partenaires et bénévoles, un dataset que nous partageons en open data, afin que les images collectées et annotées puissent servir au plus grand nombre."
 
     steps:
       title: "Comment ça marche ?"
@@ -343,6 +343,10 @@ t:
         icon_src: "/img/cards_icons/grid-view-solid.svg"
         title: "Modular"
         content: "We offer a complete detection pipeline but our system has been designed to work with existing equipment (use of cameras already in place, connection with existing software ...)"
+      card8:
+        icon_src: "/img/cards_icons/share.svg"
+        title: "Open data" 
+        content: "With the help of our partners and volunteers, we are building a dataset that we are sharing as Open Data, so that the images collected and annotated can be used by as many people as possible."
     steps:
       title: "How does it work?"
       text1: "Pyronear is a <b>complete fire risk management solution</b>. It consists of an <b>early wildfire detection algorithm</b>, implemented on a microcomputer, connected to <b>cameras positioned on high spots</b> with a view on the forest. Our detectors communicate <b>fire alerts<b> to a database that is connected to a <b>supervision platform</b> for the fire department."
@@ -504,6 +508,10 @@ t:
         icon_src: "/img/cards_icons/grid-view-solid.svg"
         title: "Modular"
         content: "Oferim un sistema de detecció complet però el nostre dispositiu ha estat dissenyat per funcionar amb equips existents (ús de càmeres ja instal·lades, connexió amb programari existent...)"
+      card8:
+        icon_src: "/img/cards_icons/share.svg"
+        title: "Open data" 
+        content: "Amb l'ajuda dels nostres socis i voluntaris, estem construint un conjunt de dades que compartim com a Open Data, de manera que les imatges recollides i anotades puguin ser utilitzades per tantes persones com sigui possible."
     steps:
       title: "Com funciona ?"
       text1: "Pyronear és un <b>solució completa de gestió del risc d'incendi</b>. Consta d'un <b>algorisme de detecció precoç d'incendis forestals</b>, implementat en un microordinador, connectat a <b>càmeres col·locades en punts alts</b> amb vistes al bosc. Els nostres detectors es comuniquen <b>alertes d'incendi<b> a una base de dades connectada a <b>plataforma de supervisió</b> per al cos de bombers."
@@ -665,6 +673,10 @@ t:
         icon_src: "/img/cards_icons/grid-view-solid.svg"
         title: "Modular"
         content: "Ofrecemos un sistema de detección completo pero nuestro dispositivo ha sido diseñado para trabajar con equipos existentes (uso de cámaras ya instaladas, conexión con software existente...)"
+      card8:
+        icon_src: "/img/cards_icons/share.svg"
+        title: "Open data" 
+        content: "Con la ayuda de nuestros asociados y voluntarios, estamos construyendo un banco de datos que compartimos como Open Data, para que las imágenes recogidas y anotadas puedan ser utilizadas por el mayor número posible de personas."
     steps:
       title: "Como funciona ?"
       text1: "Pironear es un <b>solución completa de gestión de riesgos de incendio</b>. consiste en un <b>early algoritmo de detección de incendios forestales</b>, implementado en una microcomputadora, conectada a <b>cámaras colocadas en puntos altos</b> con vista al bosque. Nuestros detectores se comunican <b>alertas de incendios<b> a una base de datos que está conectada a un <b>plataforma de supervisión</b> para el cuerpo de bomberos."

--- a/_config.yml
+++ b/_config.yml
@@ -175,6 +175,11 @@ t:
         icon_src: "/img/cards_icons/grid-view-solid.svg"
         title: "Modulable" 
         content: "Nous proposons un système de détection complet mais notre dispositif a été pensé pour fonctionner avec le matériel existant (utilisation de caméras déjà en place, connexion avec nexSIS …)"
+      card8:
+        icon_src: "/img/cards_icons/share.svg"
+        title: "Open data" 
+        content: "Nous construisons à l’aide de nos partenaires et bénévoles, un dataset que nous partageons en open data, afin que les images collectées et annotées puissent servir au plus grande nombre."
+
     steps:
       title: "Comment ça marche ?"
       text1: "Pyronear est une <b>solution complète de gestion du risque incendie</b>. Elle est constituée d’un <b>algorithme de détection</b> précoce des départs de feu, implémenté sur un micro ordinateur, connecté à des <b>caméras positionnées sur des points hauts</b> avec vue sur la forêt. Nos détecteurs communiquent les <b>alertes de détection de départ de feu</b> à une base de données elle-même connectée à une <b>plateforme de supervision</b> à destination des pompiers. "

--- a/_includes/manifesto.html
+++ b/_includes/manifesto.html
@@ -15,7 +15,7 @@
 
             <!-- Première ligne avec plus de cartes -->
             <div class="row center-flex">
-              {% assign cards = "card1,card2,card3,card4" | split: "," %}
+              {% assign cards = "card1,card2,card8" | split: "," %}
               {% for card in cards %}
                 <div class="col-md-3 col-sm-6 column-flex">
                   <div class="custom-panel column-flex">
@@ -29,7 +29,21 @@
 
             <!-- Deuxième ligne avec moins de cartes -->
             <div class="row small-row center-flex py-md-3">
-              {% assign cards = "card5,card6,card7" | split: "," %}
+              {% assign cards = "card6,card5" | split: "," %}
+              {% for card in cards %}
+                <div class="col-lg-3 col-md-6 column-flex">
+                  <div class="custom-panel column-flex">
+                      <img src="{{ site.t.[layout.lang].manifesto[card].icon_src }}" alt="Card icon" class="svg-icon">
+                      <h3>{{ site.t.[layout.lang].manifesto[card].title }}</h3>
+                      <p>{{ site.t.[layout.lang].manifesto[card].content }}</p>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+
+            <!-- 3d line with 3 cards  -->
+            <div class="row small-row center-flex py-md-3">
+              {% assign cards = "card3,card4,card7" | split: "," %}
               {% for card in cards %}
                 <div class="col-lg-3 col-md-6 column-flex">
                   <div class="custom-panel column-flex">

--- a/_includes/manifesto.html
+++ b/_includes/manifesto.html
@@ -13,7 +13,7 @@
 
           <div class="container text-muted ">
 
-            <!-- Première ligne avec plus de cartes -->
+            <!-- 1st line with 3 cards -->
             <div class="row center-flex">
               {% assign cards = "card1,card2,card8" | split: "," %}
               {% for card in cards %}
@@ -27,7 +27,7 @@
               {% endfor %}
             </div>
 
-            <!-- Deuxième ligne avec moins de cartes -->
+            <!-- 2st line with 2 cards  -->
             <div class="row small-row center-flex py-md-3">
               {% assign cards = "card6,card5" | split: "," %}
               {% for card in cards %}

--- a/img/cards_icons/share.svg
+++ b/img/cards_icons/share.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 6a4 4 0 10-7.912.838L9.017 9.373a4 4 0 10-.329 5.589l5.33 2.665a4 4 0 10.686-1.893l-4.912-2.456a3.996 3.996 0 00.12-2.116l5.071-2.535A4 4 0 0022 6z" fill="currentColor"/></svg>

--- a/img/cards_icons/sources.txt
+++ b/img/cards_icons/sources.txt
@@ -5,3 +5,4 @@ rocket.svg CC BY 4.0 https://iconduck.com/icons/22306/rocket
 eco.scg Apache 2 https://iconduck.com/icons/28790/eco 
 savings-solid.svg MIT https://iconduck.com/icons/100582/savings-solid
 grid-view-solid.svg MIT https://iconduck.com/icons/100862/grid-view-solid
+share.svg MIT https://iconduck.com/icons/109278/share


### PR DESCRIPTION
## 📰 Short Description 

In the near future, we are planning to add a section dedicated to open data. 

As of today, this PR adds Open Data card to manifesto as long as it is key part of Pyronear project. 

This PR includes the following modifications : 
- Adds a svg for open data (& quotes the source)
- Adds open data card to manifesto (in all langages)
- Reorganizes cards

As you can see in screenshots, the expected behaviour is obtained. 

Happy to discuss it and have feedbacks from translations ;) 

## 📸 Screenshots 
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/ae061c2b-8c6a-4434-b7ad-9297374cebee" />
<img width="817" alt="image" src="https://github.com/user-attachments/assets/c4564d54-10ea-4e48-9a8c-070ca2ef3921" />
<img width="1459" alt="image" src="https://github.com/user-attachments/assets/0af1666b-ba7d-41b7-b60f-d2bfb4362831" />


## Guidelines
### Translation
If your modification includes text, it is likely that you are not fluent in one of the languages in which the site is distributed. 
In this case, we suggest that you use [DeepL](https://www.deepl.com/fr/translator) for translation and specify the languages for which you have used it. 
Deepl used for translation in :
- [ ] French
- [ ] English
- [X] Spanish
- [X] Catalan


