### PR TITLE
Correct sciences et avenir photo link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,7 @@ medias:
     - title: "À Fontainebleau, une IA sobre en énergie s'entraîne à détecter les feux de forêt"
       url: "https://www.sciencesetavenir.fr/nature-environnement/a-fontainebleau-une-ia-sobre-en-energie-s-entraine-a-detecter-les-feux-de-foret_188336"
       logo: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Sciences_et_Avenir_2024.jpg/500px-Sciences_et_Avenir_2024.jpg"
-      image: "https://www.sciencesetavenir.fr/assets/img/2025/09/23/cover-r4x3w1200-68d2413d77f24-e8bda95730789a3609aaea6cf6422a7fc24c9015-jpg.jpg"
+      image: "https://s.france24.com/media/display/4a6b44e2-9848-11f0-bc5a-005056bfb2b6/w:1280/p:16x9/5c92b7c99074e3b2d34166db150033095a968a73.webp"
       date: "09.2025"
       width: 200
 #    - title: "TV5 monde Fontainebleau"


### PR DESCRIPTION
## 📰 Short Description 
Correct a dead link on the sciences et avenir article

## 📸 Screenshots 
<img width="342" height="572" alt="image" src="https://github.com/user-attachments/assets/603cb044-8b82-460e-b0dd-ebf56b208161" />