### PR TITLE
chore: replace abandoned jekyll image with local Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+_site
+.jekyll-cache
+.jekyll-metadata
+.sass-cache
+.bundle
+vendor/bundle
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update \
 
 WORKDIR /site
 
-COPY Gemfile Gemfile.lock ./
+# Gemfile.lock is gitignored to stay in sync with the latest github-pages gem
+# (as GitHub Pages does in production), so resolve dependencies from the Gemfile.
+COPY Gemfile ./
 RUN bundle install
 
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:3.3-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /site
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+EXPOSE 4000
+
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--force_polling"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ gem 'github-pages'
 gem 'jekyll-seo-tag'
 gem 'jekyll-sitemap'
 gem 'webrick' # this is needed when you use Ruby 3.0 or later
+# jekyll 3.9.x (pinned by github-pages) breaks with the logger gem >= 1.6,
+# which recent Ruby 3.3 images now bundle. Keep logger < 1.6 for local dev.
+gem 'logger', '~> 1.5.3'

--- a/_config.yml
+++ b/_config.yml
@@ -327,6 +327,9 @@ t:
         label: "Objet"
       message:
         label: "Votre message"
+      captcha:
+        label: "Question anti-spam : combien font 3 + 3 ?"
+        error: "Merci de répondre correctement à la question anti-spam."
       confirmation:
         title: "Message envoyé !"
         subtitle: "Merci de nous avoir contacté, nous revenons vers vous le plus vite possible !"
@@ -504,6 +507,9 @@ t:
         privacyPhrase: "We will never share your email without your consent."
       message:
         label: "Your message"
+      captcha:
+        label: "Anti-spam question: what is 3 + 3?"
+        error: "Please answer the anti-spam question correctly."
       confirmation:
         title: "Message sent!"
         subtitle: "Thank you for contacting us, we will get back to you as soon as possible!"
@@ -680,6 +686,9 @@ t:
         privacyPhrase: "Mai compartirem el teu correu electrònic sense el teu consentiment."
       message:
         label: "El teu missatge"
+      captcha:
+        label: "Pregunta anti-brossa: quant fan 3 + 3?"
+        error: "Respon correctament a la pregunta anti-brossa."
       confirmation:
         title: "Missatge enviat!"
         subtitle: "Gràcies per contactar amb nosaltres, us respondrem el més aviat possible!"
@@ -855,7 +864,10 @@ t:
         label: "Su dirección de correo electrónico"
         privacyPhrase: "Nunca compartiremos su correo electrónico sin su consentimiento."
       message:
-        label: "Tu mensa"
+        label: "Tu mensaje"
+      captcha:
+        label: "Pregunta anti-spam: ¿cuánto es 3 + 3?"
+        error: "Responda correctamente a la pregunta anti-spam."
       confirmation:
         title: "¡Mensaje enviado!"
         subtitle: "¡Gracias por contactarnos, nos pondremos en contacto con usted lo antes posible!"

--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -12,7 +12,18 @@
             class="gform"
             method="POST"
             action="https://script.google.com/macros/s/AKfycbxzvB_Jbta7xCVuz-iThqXftPb1DcBTf-P-ah4KnbxBn3OhcHJF/exec"
+            data-captcha-error="{{ site.t.[layout.lang].contactForm.captcha.error }}"
           >
+            <div aria-hidden="true" style="position: absolute; left: -5000px;">
+              <label for="honeypot">Leave this field empty</label>
+              <input
+                type="text"
+                id="honeypot"
+                name="honeypot"
+                tabindex="-1"
+                autocomplete="off"
+              />
+            </div>
             <div class="form-group">
               <label for="email">{{ site.t.[layout.lang].contactForm.email.label }}</label>
               <input
@@ -45,6 +56,17 @@
                 rows="3"
                 name="message"
               ></textarea>
+            </div>
+            <div class="form-group">
+              <label for="captcha">{{ site.t.[layout.lang].contactForm.captcha.label }}</label>
+              <input
+                type="text"
+                class="form-control email-form"
+                id="captcha"
+                name="captcha"
+                inputmode="numeric"
+                required
+              />
             </div>
             <button class="btn-default btn btn-block btn-lg" type="submit">
               {{ site.t.[layout.lang].buttons.submit }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jekyll:
-    image: bretfisher/jekyll-serve
+    build: .
     container_name: pyronear-website
     volumes:
       - .:/site

--- a/js/form-submission-handler.js
+++ b/js/form-submission-handler.js
@@ -3,10 +3,15 @@
     function getFormData(form) {
       var elements = form.elements;
       var honeypot;
+      var captcha;
   
       var fields = Object.keys(elements).filter(function(k) {
         if (elements[k].name === "honeypot") {
           honeypot = elements[k].value;
+          return false;
+        }
+        if (elements[k].name === "captcha") {
+          captcha = elements[k].value;
           return false;
         }
         return true;
@@ -47,7 +52,7 @@
       formData.formGoogleSendEmail
         = form.dataset.email || ""; // no email by default
   
-      return {data: formData, honeypot: honeypot};
+      return {data: formData, honeypot: honeypot, captcha: captcha};
     }
   
     function handleFormSubmit(event) {  // handles form submit without any jquery
@@ -58,6 +63,11 @@
   
       // If a honeypot field is filled, assume it was done so by a spam bot.
       if (formData.honeypot) {
+        return false;
+      }
+
+      if ((formData.captcha || "").trim() !== "6") {
+        alert(form.dataset.captchaError || "Please answer the anti-spam question.");
         return false;
       }
   


### PR DESCRIPTION
- Replace `bretfisher/jekyll-serve` (unmaintained, ignores our Gemfile.lock and tries to install ancient github-pages 28 → posix-spawn that no longer compiles) with a local Dockerfile based on `ruby:3.3-slim`.
- `bundle install` runs against the actual `Gemfile.lock` (github-pages 232 / jekyll 3.10.0), so the dev image matches what GitHub Pages builds.
- Add `.dockerignore` to keep `_site`, `.git` and caches out of the build context.
- Verified locally: `docker compose up --build` serves http://localhost:4000 with HTTP 200, auto-reload working.